### PR TITLE
Set UTC as the default timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Add this line to your application's Gemfile:
 Create '.rrrspec'
 
     RRRSpec.configure(:client) do |conf|
+      Time.zone_default = Time.find_zone('Asia/Tokyo')
       conf.redis = { host: 'redisserver.local', port: 6379 }
 
       conf.packaging_dir = `git rev-parse --show-toplevel`.strip
@@ -78,6 +79,7 @@ Install 'rrrspec-server'
 Create 'rrrspec-server-config.rb'
 
     RRRSpec.configure(:server) do |conf|
+      ActiveRecord::Base.default_timezone = :local
       conf.redis = { host: 'redisserver.local', port: 6379 }
 
       conf.rsync_server = 'rsyncserver.local'

--- a/rrrspec-client/lib/rrrspec.rb
+++ b/rrrspec-client/lib/rrrspec.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext'
 require 'active_support/time'
 require 'socket'
 require 'logger'
-Time.zone_default = Time.find_zone!(Time.now.zone)
+Time.zone_default = Time.find_zone('UTC')
 
 require 'rrrspec/configuration'
 require 'rrrspec/redis_models'
@@ -96,7 +96,7 @@ module RRRSpec
     end
 
     def write(string)
-      now = Time.now
+      now = Time.zone.now
       @obj.append_log(now.strftime("%F %T ") + string + "\n")
     end
   end

--- a/rrrspec-client/rrrspec-client.gemspec
+++ b/rrrspec-client/rrrspec-client.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rspec", ">= 2.14.1"
   spec.add_dependency "thor"
   spec.add_dependency "uuidtools"
+  spec.add_dependency "tzinfo"
 end

--- a/rrrspec-server/Gemfile
+++ b/rrrspec-server/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'rrrspec-client', path: '../'
 gemspec

--- a/rrrspec-server/lib/rrrspec/server/persister.rb
+++ b/rrrspec-server/lib/rrrspec/server/persister.rb
@@ -4,7 +4,7 @@ require 'active_support/inflector'
 ActiveSupport::Inflector::Inflections.instance.singular('Slaves', 'Slave')
 ActiveSupport::Inflector::Inflections.instance.singular('slaves', 'slave')
 ActiveRecord::Base.include_root_in_json = false
-ActiveRecord::Base.default_timezone = :local
+ActiveRecord::Base.default_timezone = :utc
 
 module RRRSpec
   module Server

--- a/rrrspec-web/Gemfile
+++ b/rrrspec-web/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'rrrspec-client', path: '../'
+gem 'rrrspec-server', path: '../'
 gemspec


### PR DESCRIPTION
Since not all of the return value of `Time.now.zone` are always recognized
by TZInfo, `Time.find_zone!` should be avoided. The reason why it does not
recognize is that `Time.now.zone` returns the timezone string generated by
`strftime` while TZInfo uses zoneinfo library, and there is no consistency
between them. Moreover, it is problematic that there is no conformance with
`ActiveRecord::Base.default_timezone` to `Time.now.zone`.

This commit resorts to set the default timezone to UTC and let users specify
their timezone in the configuration files as documented in README.
