### PR TITLE
Do not split the rsync server and the remote path

### DIFF
--- a/PROTOCOL.txt
+++ b/PROTOCOL.txt
@@ -1,7 +1,5 @@
  1. Server started
 
-   RSyncInfo.heartbeat(...)
-
  2. Worker spawned
 
    worker = Worker.create(...)
@@ -88,8 +86,7 @@
 
 rrrspec:rsync_info
   hash[
-    rsync_server: 'rsyncuser@server.local'
-    rsync_dir: '/home/rsyncuser/rrrspec'
+    rsync_remote_path: 'rsyncuser@server.local:/home/rsyncuser/rrrspec'
     rsync_options: '--delete ...'
   ]
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Create '.rrrspec'
       conf.redis = { host: 'redisserver.local', port: 6379 }
 
       conf.packaging_dir = `git rev-parse --show-toplevel`.strip
-      conf.packaging_rsync_options = %w(
+      conf.rsync_remote_path = 'rsyncserver.local:/mnt/rrrspec-rsync'
+      conf.rsync_options = %w(
         --compress
         --times
         --recursive
@@ -82,18 +83,6 @@ Create 'rrrspec-server-config.rb'
       ActiveRecord::Base.default_timezone = :local
       conf.redis = { host: 'redisserver.local', port: 6379 }
 
-      conf.rsync_server = 'rsyncserver.local'
-      conf.rsync_dir = '/mnt/rrrspec-rsync'
-      conf.rsync_options = %w(
-        --compress
-        --times
-        --recursive
-        --links
-        --perms
-        --inplace
-        --delete
-      ).join(' ')
-
       conf.persistence_db = {
         adapter: 'mysql2',
         encoding: 'utf8mb4',
@@ -110,6 +99,17 @@ Create 'rrrspec-server-config.rb'
     RRRSpec.configure(:worker) do |conf|
       conf.redis = { host: 'redisserver.local', port: 6379 }
     
+      conf.rsync_remote_path = 'rsyncserver.local:/mnt/rrrspec-rsync'
+      conf.rsync_options = %w(
+        --compress
+        --times
+        --recursive
+        --links
+        --perms
+        --inplace
+        --delete
+      ).join(' ')
+
       conf.working_dir = '/mnt/working'
       conf.worker_type = 'default'
     end

--- a/local_test/rrrspec_clients.rb
+++ b/local_test/rrrspec_clients.rb
@@ -1,5 +1,6 @@
 RRRSpec.configure(:client) do |conf|
-  conf.packaging_rsync_options = [
+  conf.rsync_remote_path = "localhost:#{File.expand_path("../tmp/server-rsync", __FILE__)}"
+  conf.rsync_options = [
     '--compress',
     '--times',
     '--recursive',

--- a/local_test/rrrspec_servers.rb
+++ b/local_test/rrrspec_servers.rb
@@ -1,17 +1,8 @@
 RRRSpec.configure(:server) do |conf|
+  FileUtils.mkdir_p(File.expand_path("../tmp/server-rsync", __FILE__))
+
   RRRSpec.logger = Logger.new(File.expand_path("../tmp/server.log", __FILE__))
   RRRSpec.logger.formatter = Logger::Formatter.new
-  conf.rsync_server = 'localhost'
-  conf.rsync_dir = File.expand_path("../tmp/server-rsync", __FILE__)
-  conf.rsync_options = %w(
-    --compress
-    --times
-    --recursive
-    --links
-    --perms
-    --inplace
-    --delete
-  ).join(' ')
   conf.persistence_db = {
     adapter: 'sqlite3',
     database: File.expand_path("../tmp/local_test.db", __FILE__)
@@ -22,6 +13,16 @@ end
 RRRSpec.configure(:worker) do |conf|
   RRRSpec.logger = Logger.new(File.expand_path("../tmp/worker.log", __FILE__))
   RRRSpec.logger.formatter = Logger::Formatter.new
+  conf.rsync_remote_path = "localhost:#{File.expand_path("../tmp/server-rsync", __FILE__)}"
+  conf.rsync_options = %w(
+    --compress
+    --times
+    --recursive
+    --links
+    --perms
+    --inplace
+    --delete
+  ).join(' ')
   conf.worker_type = 'default'
   conf.working_dir = File.expand_path("../tmp/worker/working", __FILE__)
 end

--- a/rrrspec-client/lib/rrrspec/client/cli.rb
+++ b/rrrspec-client/lib/rrrspec/client/cli.rb
@@ -67,8 +67,6 @@ module RRRSpec
       desc 'nodes', 'list up the active nodes'
       def nodes
         setup(Configuration.new)
-        puts "Server:"
-        puts "\t#{RSyncInfo.exist? ? "Yes" : "No"}"
         puts "Workers:"
         Worker.list.each { |worker| puts "\t#{worker.key}" }
       end

--- a/rrrspec-client/lib/rrrspec/client/configuration.rb
+++ b/rrrspec-client/lib/rrrspec/client/configuration.rb
@@ -2,7 +2,7 @@ module RRRSpec
   module Client
     class ClientConfiguration < Configuration
       attr_accessor :packaging_dir
-      attr_accessor :packaging_rsync_options
+      attr_accessor :rsync_remote_path, :rsync_options
       attr_writer :spec_files
       attr_accessor :setup_command, :slave_command
       attr_accessor :taskset_class, :worker_type

--- a/rrrspec-client/lib/rrrspec/client/support.rb
+++ b/rrrspec-client/lib/rrrspec/client/support.rb
@@ -112,9 +112,8 @@ module RRRSpec
 
       def run_rsync_package(rsync_name)
         conf = RRRSpec.configuration
-        remote_dir = File.join(RSyncInfo.rsync_dir, rsync_name)
-        remote_path = "#{RSyncInfo.rsync_server}:#{remote_dir}"
-        command = "rsync #{conf.packaging_rsync_options} #{conf.packaging_dir}/ #{remote_path}"
+        remote_path = File.join(conf.rsync_remote_path, rsync_name)
+        command = "rsync #{conf.rsync_options} #{conf.packaging_dir}/ #{remote_path}"
         $stderr.puts command
         system(command)
         $?.success?

--- a/rrrspec-client/lib/rrrspec/redis_models.rb
+++ b/rrrspec-client/lib/rrrspec/redis_models.rb
@@ -10,62 +10,6 @@ module RRRSpec
     end
   end
 
-  module RSyncInfo
-    WAIT_SERVER_SEC = 10
-    RSYNC_INFO_KEY = 'rrrspec:rsync_info'
-
-    module_function
-
-    def self.hget_loop(key)
-      loop do
-        v = RRRSpec.redis.hget(RSYNC_INFO_KEY, key)
-        return v if v.present?
-        sleep WAIT_SERVER_SEC
-      end
-    end
-
-    # Public
-    def self.rsync_server
-      hget_loop('rsync_server')
-    end
-
-    # Public
-    def self.rsync_dir
-      hget_loop('rsync_dir')
-    end
-
-    # Public
-    def self.rsync_options
-      hget_loop('rsync_options')
-    end
-
-    # ==========================================================================
-    # Heartbeat
-
-    # Public: Check its existence.
-    #
-    # Returns bool
-    def self.exist?
-      RRRSpec.redis.exists('rrrspec:rsync_info')
-    end
-
-    # Public: Maintain heartbeat
-    def self.heartbeat(time)
-      unless Dir.exist?(RRRSpec.configuration.rsync_dir)
-        FileUtils.makedirs(RRRSpec.configuration.rsync_dir)
-      end
-      RRRSpec.redis.multi do
-        RRRSpec.redis.hmset(
-          'rrrspec:rsync_info',
-          'rsync_server', RRRSpec.configuration.rsync_server,
-          'rsync_dir', RRRSpec.configuration.rsync_dir,
-          'rsync_options', RRRSpec.configuration.rsync_options
-        )
-        RRRSpec.redis.expire('rrrspec:rsync_info', time)
-      end
-    end
-  end
-
   module ArbiterQueue
     ARBITER_QUEUE_KEY = 'rrrspec:arbiter_queue'
 

--- a/rrrspec-server/lib/rrrspec/server/cli.rb
+++ b/rrrspec-server/lib/rrrspec/server/cli.rb
@@ -78,7 +78,6 @@ module RRRSpec
         auto_rebirth do
           ActiveRecord::Base.establish_connection(**RRRSpec.configuration.persistence_db)
           Thread.abort_on_exception = true
-          Thread.fork { RRRSpec.pacemaker(RSyncInfo, 60, 5) }
           Thread.fork { Dispatcher.work_loop }
           Thread.fork { Arbiter.work_loop }
           Thread.fork { Persister.work_loop }

--- a/rrrspec-server/lib/rrrspec/server/configuration.rb
+++ b/rrrspec-server/lib/rrrspec/server/configuration.rb
@@ -3,7 +3,6 @@ require 'facter'
 module RRRSpec
   module Server
     class ServerConfiguration < Configuration
-      attr_accessor :rsync_server, :rsync_dir, :rsync_options
       attr_accessor :persistence_db
       attr_accessor :execute_log_text_path
       attr_accessor :json_cache_path
@@ -15,11 +14,6 @@ module RRRSpec
 
       def check_validity
         validity = super
-
-        unless rsync_server and rsync_options and rsync_dir
-          $stderr.puts('The rsync options are not set')
-          validity = false
-        end
 
         unless execute_log_text_path
           $stderr.puts('The path to save the log text should be set')
@@ -36,6 +30,7 @@ module RRRSpec
     end
 
     class WorkerConfiguration < Configuration
+      attr_accessor :rsync_remote_path, :rsync_options
       attr_accessor :working_dir, :worker_type, :slave_processes
 
       def initialize
@@ -47,6 +42,11 @@ module RRRSpec
 
       def check_validity
         validity = super
+
+        unless rsync_remote_path and rsync_options
+          $stderr.puts('The rsync options are not set')
+          validity = false
+        end
 
         unless working_dir and worker_type
           $stderr.puts('The worker options are not set')

--- a/rrrspec-server/lib/rrrspec/server/worker_runner.rb
+++ b/rrrspec-server/lib/rrrspec/server/worker_runner.rb
@@ -24,8 +24,8 @@ module RRRSpec
 
         working_path = File.join(RRRSpec.configuration.working_dir, taskset.rsync_name)
         FileUtils.mkdir_p(working_path) unless Dir.exists?(working_path)
-        remote_path = "#{RSyncInfo.rsync_server}:#{File.join(RSyncInfo.rsync_dir, taskset.rsync_name)}"
-        command = "rsync #{RSyncInfo.rsync_options} #{remote_path}/ #{working_path}"
+        remote_path = File.join(RRRSpec.configuration.rsync_remote_path, taskset.rsync_name)
+        command = "rsync #{RRRSpec.configuration.rsync_options} #{remote_path}/ #{working_path}"
 
         pid, out_rd, err_rd = execute_with_logs(working_path, command, {})
         log_to_logger(logger, out_rd, err_rd)


### PR DESCRIPTION
It is troublesome to split the rsync server and the remote path under the
situation that the system uses rsyncd.

It also moves rsync settings to the workers and clients from the server. This is
because It is possible that the rsync command in the workers and the one in the
clients are different.
