### PR TITLE
Defer setting the short timeout sec

### DIFF
--- a/rrrspec-client/lib/rrrspec/client/slave_runner.rb
+++ b/rrrspec-client/lib/rrrspec/client/slave_runner.rb
@@ -45,15 +45,15 @@ module RRRSpec
           @timeout = TASKQUEUE_ARBITER_TIMEOUT
           ArbiterQueue.check(@taskset)
         else
-          @timeout = TASKQUEUE_TASK_TIMEOUT
           if @worked_task_keys.include?(task.key)
             @taskset.reversed_enqueue_task(task)
             return
           else
             @worked_task_keys << task.key
           end
-
           return if task.status.present?
+
+          @timeout = TASKQUEUE_TASK_TIMEOUT
           trial = Trial.create(task, @slave)
 
           @rspec_runner.reset


### PR DESCRIPTION
There is a situation that the check requests are enormously issued. When there
are few tasks left and one slave already tried them, the slave repeatedly
requests a task and issues check requests. The example sequence is like below:
1. Slave1 tries to dequeues a task, and there is no tasks left.
2. Slave1 issues a check request, and it sets the long timeout sec to wait for
   the arbiter's judge.
3. Arbiter enqueues a task, which Slave1 already has already tried.
4. Slave1 dequeues a task, and since the slave has been already tried the task,
   it pushes back the task. It sets the short timeout sec as usual.
5. Slave2 dequeues a task.
6. Slave1 tries to dequeues a task, and there is no tasks left.
7. Back to 2.

It is the intended behavior, except that the timeout speed in the step 6 is
faster than expected. This is because, in the step 4, it sets the short timeout
time. This commit defers setting the timeout sec.
