### PR TITLE
Save the large log texts in the subdirectories.

### DIFF
--- a/rrrspec-server/lib/rrrspec/server/log_file_persister.rb
+++ b/rrrspec-server/lib/rrrspec/server/log_file_persister.rb
@@ -11,12 +11,13 @@ module RRRSpec
     #
     # * Have a property named 'key'
     # * Set RRRSpec.configuration.execute_log_text_path
+    # * Have a singleton method :after_save
     #
     # Provides:
     #
     # * Methods named 'log', 'log=', 'log_log_path'.
     # * 'after_save' hook that persists a log to the file pointed by log_log_path.
-    # * Persist the value of the 'log' to File.join(execute_log_text_path, "#{key}_log.log") if it is dirty.
+    # * Persist the value of the 'log' to File.join(execute_log_text_path, "#{key.gsub(/\//, '_').gsub(/:/, '/')}_log.log") if it is dirty.
     module LogFilePersister
       extend ActiveSupport::Concern
 
@@ -28,7 +29,7 @@ module RRRSpec
             return nil unless send(:key)
             File.join(
               RRRSpec.configuration.execute_log_text_path,
-              "#{send(:key).gsub(/[\/:]/, '_')}#{suffix}.log"
+              "#{send(:key).gsub(/\//, '_').gsub(/:/, '/')}#{suffix}.log"
             )
           end
 

--- a/rrrspec-server/spec/rrrspec/server/log_file_persister_spec.rb
+++ b/rrrspec-server/spec/rrrspec/server/log_file_persister_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module RRRSpec
+  module Server
+    class TestClass
+      include LogFilePersister
+      def self.after_save(&block); end
+      save_as_file :log, suffix: 'log'
+
+      attr_accessor :key
+    end
+
+    describe LogFilePersister do
+      before do
+        RRRSpec.configuration = ServerConfiguration.new
+        RRRSpec.configuration.execute_log_text_path = '/tmp/log_path'
+      end
+
+      describe '#log_log_path' do
+        subject { TestClass.new }
+
+        it 'subsitutes colons in the key' do
+          subject.key = 'rrrspec:test'
+          expect(subject.log_log_path).to eq('/tmp/log_path/rrrspec/test_log.log')
+        end
+
+        it 'subsitutes slashes in the key' do
+          subject.key = 'rrrspec:test/path'
+          expect(subject.log_log_path).to eq('/tmp/log_path/rrrspec/test_path_log.log')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It is the case that the execute_log_text_path has full of entries and it leads
ENOSPC when creating a new file. Avoid this error by digging deeper into the
subdirectories.
