### PR TITLE
Support stdout and stderr redirection on daemonize

### DIFF
--- a/rrrspec-server/lib/rrrspec/server/configuration.rb
+++ b/rrrspec-server/lib/rrrspec/server/configuration.rb
@@ -7,6 +7,7 @@ module RRRSpec
       attr_accessor :execute_log_text_path
       attr_accessor :json_cache_path
       attr_accessor :daemonize, :pidfile, :user
+      attr_accessor :stdout_path, :stderr_path
 
       def initialize
         super()
@@ -34,6 +35,7 @@ module RRRSpec
       attr_accessor :rsync_remote_path, :rsync_options
       attr_accessor :working_dir, :worker_type, :slave_processes
       attr_accessor :daemonize, :pidfile, :user
+      attr_accessor :stdout_path, :stderr_path
 
       def initialize
         super()

--- a/rrrspec-server/lib/rrrspec/server/daemonizer.rb
+++ b/rrrspec-server/lib/rrrspec/server/daemonizer.rb
@@ -9,6 +9,12 @@ module RRRSpec
       pidfile = File.absolute_path(RRRSpec.configuration.pidfile || File.join("/var/run", "#{process_name}.pid"))
       check_pidfile(pidfile)
 
+      if stdout_path = RRRSpec.configuration.stdout_path
+        $stdout.reopen(stdout_path, 'a')
+      end
+      if stderr_path = RRRSpec.configuration.stderr_path
+        $stderr.reopen(stderr_path, 'a')
+      end
       Process.daemon
       File.write(pidfile, Process.pid.to_s)
       File.umask(0)


### PR DESCRIPTION
When server or worker exists abnormally, it's hard to know what happened since it throws out stdout and stderr.
