### PR TITLE
Show worker type with node name

### DIFF
--- a/rrrspec-client/lib/rrrspec/client/cli.rb
+++ b/rrrspec-client/lib/rrrspec/client/cli.rb
@@ -68,7 +68,16 @@ module RRRSpec
       def nodes
         setup(Configuration.new)
         puts "Workers:"
-        Worker.list.each { |worker| puts "\t#{worker.key}" }
+        workers = Hash.new { |h, k| h[k] = [] }
+        Worker.list.each do |worker|
+          workers[worker.worker_type] << worker.key
+        end
+        workers.keys.sort.each do |k|
+          puts "  #{k}:"
+          workers[k].sort.each do |name|
+            puts "    #{name}"
+          end
+        end
       end
 
       option :pollsec, type: :numeric, default: WAIT_POLLING_SEC


### PR DESCRIPTION
Before:

```
Workers:
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
        rrrspec:worker:rrrspec-worker-XXXXXXXXXX
```

After:

```
Workers:
  default:
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
  special:
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
    rrrspec:worker:rrrspec-worker-XXXXXXXXXX
```

@cookpad/rrrspec :eyeglasses: 