### PR TITLE
Making the gem buildable again

### DIFF
--- a/rrrspec-web/rrrspec-web.gemspec
+++ b/rrrspec-web/rrrspec-web.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "api-pagination"
   spec.add_dependency "bootstrap-sass", ">= 3.2"
   spec.add_dependency "coffee-script", "~> 2.2.0"
-  spec.add_dependency "grape"
+  spec.add_dependency "grape", '~> 0.9.0'
   spec.add_dependency "haml", "~> 4.0.3"
   spec.add_dependency "kaminari", "~> 0.15.0"
   spec.add_dependency "oj"

--- a/rrrspec-web/rrrspec-web.gemspec
+++ b/rrrspec-web/rrrspec-web.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "coffee-script", "~> 2.2.0"
   spec.add_dependency "grape", '~> 0.9.0'
   spec.add_dependency "haml", "~> 4.0.3"
-  spec.add_dependency "kaminari", "~> 0.15.0"
+  spec.add_dependency "kaminari", "~> 0.16.0"
   spec.add_dependency "oj"
   spec.add_dependency "rrrspec-client"
   spec.add_dependency "rrrspec-server"


### PR DESCRIPTION
I just found that currently rrrspec gem cannot be installed, because of dependency mismatch between rrrspec and old version of kaminari's Gemfile.

```
% gem -v
2.4.5

% gem i rrrspec
ERROR:  While executing gem ... (Gem::DependencyResolutionError)
    conflicting dependencies activemodel (= 3.0.0) and activemodel (= 4.0.2)
  Activated activemodel-4.0.2
  which does not match conflicting dependency (= 3.0.0)

  Conflicting dependency chains:
    rrrspec (>= 0), 0.2.2 activated, depends on
    rrrspec-web (= 0.2.2), 0.2.2 activated, depends on
    activerecord (~> 4.0.2), 4.0.2 activated, depends on
    activemodel (= 4.0.2), 4.0.2 activated

  versus:
    rrrspec (>= 0), 0.2.2 activated, depends on
    rrrspec-web (= 0.2.2), 0.2.2 activated, depends on
    kaminari (~> 0.15.0), 0.15.1 activated, depends on
    actionpack (>= 3.0.0), 3.0.0 activated, depends on
    activemodel (= 3.0.0)
```

This can be fixed by bundling newer kaminari.

Also, rrrspec-web gem cannot be built due to grape's API change.

```
% bundle ex rake build
rake aborted!
NoMethodError: undefined method `set' for RRRSpec::Web::API:Class
/Users/akira-matsuda/src/rrrspec/rrrspec-web/lib/rrrspec/web/api.rb:12:in `<class:API>'
/Users/akira-matsuda/src/rrrspec/rrrspec-web/lib/rrrspec/web/api.rb:9:in `<module:Web>'
/Users/akira-matsuda/src/rrrspec/rrrspec-web/lib/rrrspec/web/api.rb:6:in `<module:RRRSpec>'
/Users/akira-matsuda/src/rrrspec/rrrspec-web/lib/rrrspec/web/api.rb:5:in `<top (required)>'
/Users/akira-matsuda/src/rrrspec/rrrspec-web/lib/rrrspec/web.rb:7:in `<top (required)>'
/Users/akira-matsuda/src/rrrspec/rrrspec-web/tasks/assets.rake:2:in `require'
/Users/akira-matsuda/src/rrrspec/rrrspec-web/tasks/assets.rake:2:in `<top (required)>'
/Users/akira-matsuda/src/rrrspec/rrrspec-web/Rakefile:2:in `load'
/Users/akira-matsuda/src/rrrspec/rrrspec-web/Rakefile:2:in `<top (required)>'
```
I don't know how we can make the API work on the new Grape API, so here's a quick workaround that pins down the grape dependency to '< 0.10'.