### PR TITLE
Explicitly require 'AS/deprecation' for AS 4.2.0 and 4.2.1

### DIFF
--- a/rrrspec-client/lib/rrrspec.rb
+++ b/rrrspec-client/lib/rrrspec.rb
@@ -2,6 +2,7 @@ require 'redis'
 # XXX: With activesupport 4.1, we cannot require active_support/core_ext due to
 # "uninitialized constant ActiveSupport::Autoload (NameError)".
 require 'active_support/dependencies/autoload'
+require 'active_support/deprecation'
 require 'active_support/core_ext'
 require 'active_support/time'
 require 'socket'


### PR DESCRIPTION
rrrspec fails to boot with active_support 4.2.x due to AS's bug. https://github.com/rails/rails/commit/dd7bd8c023696657a600ee5dba16bfe5def876bf

```
% ./script/rrrspec
+ chmod 600 ../shared/config/id_rsa.remote_spec
++ bundle exec rrrspec start --key-only --worker-type=developer
.../activesupport-4.2.1/lib/active_support/core_ext/module/deprecation.rb:21:in `deprecate': uninitialized constant ActiveSupport::Deprecation (NameError)
	from .../activesupport-4.2.1/lib/active_support/core_ext/class/delegating_attributes.rb:26:in `<class:Class>'
...
```

Here's a workaround that explicitly requires AS/deprecation.