### PR TITLE
fix api-pagination version

### DIFF
--- a/rrrspec-web/rrrspec-web.gemspec
+++ b/rrrspec-web/rrrspec-web.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3"
   spec.add_dependency "activerecord", ">= 4.0", "< 4.2"
   spec.add_dependency "activesupport"
-  spec.add_dependency "api-pagination"
+  spec.add_dependency "api-pagination", "< 3.2.0"
   spec.add_dependency "bootstrap-sass", ">= 3.2"
   spec.add_dependency "coffee-script", "~> 2.2.0"
   spec.add_dependency "grape", '~> 0.9.0'


### PR DESCRIPTION
rrrspec-web.gemspecのgrapeのver指定が'~> 0.9.0'なのに対して、api-paginationのverが無指定なので、0.9.~系に対応した最後のバージョンを指定しないと、[この変更](https://github.com/davidcelis/api-pagination/commit/34879e81caa721dcdf7625b7b230d8ae6b048efe#diff-250ea48b4309a33ec81d33ea6a817ea0)に引っかかって怒られます(した)。
環境:https://github.com/gongo/docker-rrrspec-example
```
NoMethodError: undefined method `route_setting' for #<Grape::Endpoint:0x007fbeb4584600>
	/var/lib/gems/2.0.0/gems/api-pagination-4.1.1/lib/grape/pagination.rb:6:in `paginate'
	/opt/rrrspec/rrrspec-web/lib/rrrspec/web/api.rb:89:in `block in <class:APIv2>'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/endpoint.rb:45:in `call'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/endpoint.rb:45:in `block in generate_api_method'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/endpoint.rb:220:in `call'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/endpoint.rb:220:in `run'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/endpoint.rb:171:in `block in call!'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/base.rb:24:in `call'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/base.rb:24:in `call!'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/base.rb:18:in `call'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/base.rb:24:in `call!'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/base.rb:18:in `call'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/error.rb:27:in `block in call!'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/error.rb:26:in `catch'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/error.rb:26:in `call!'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/middleware/base.rb:18:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/endpoint.rb:172:in `call!'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/endpoint.rb:160:in `call'
	/var/lib/gems/2.0.0/gems/rack-mount-0.8.3/lib/rack/mount/route_set.rb:152:in `block in call'
	/var/lib/gems/2.0.0/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:96:in `block in recognize'
	/var/lib/gems/2.0.0/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:68:in `optimized_each'
	/var/lib/gems/2.0.0/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:95:in `recognize'
	/var/lib/gems/2.0.0/gems/rack-mount-0.8.3/lib/rack/mount/route_set.rb:141:in `call'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/api.rb:128:in `call'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/api.rb:43:in `call!'
	/var/lib/gems/2.0.0/gems/grape-0.9.0/lib/grape/api.rb:39:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/cascade.rb:33:in `block in call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/cascade.rb:24:in `each'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/cascade.rb:24:in `call'
	/var/lib/gems/2.0.0/gems/activerecord-4.1.10/lib/active_record/connection_adapters/abstract/connection_pool.rb:621:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/lint.rb:49:in `_call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/lint.rb:37:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/showexceptions.rb:24:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/commonlogger.rb:33:in `call'
	/var/lib/gems/2.0.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:218:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/chunked.rb:43:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/content_length.rb:14:in `call'
	/var/lib/gems/2.0.0/gems/rack-1.5.2/lib/rack/handler/webrick.rb:60:in `service'
	/usr/lib/ruby/2.0.0/webrick/httpserver.rb:138:in `service'
	/usr/lib/ruby/2.0.0/webrick/httpserver.rb:94:in `run'
	/usr/lib/ruby/2.0.0/webrick/server.rb:295:in `block in start_thread'
```