### PR TITLE
Update RSpec dependency

### DIFF
--- a/local_test/fail_spec.rb
+++ b/local_test/fail_spec.rb
@@ -4,7 +4,7 @@ describe 'test2' do
   end
 
   it 'will be succeeded' do
-    1.should == 1
+    expect(1).to eq(1)
   end
 
   it 'will be pending' do

--- a/local_test/fail_spec.rb
+++ b/local_test/fail_spec.rb
@@ -10,4 +10,8 @@ describe 'test2' do
   it 'will be pending' do
     pending
   end
+
+  it 'will be skipped' do
+    skip
+  end
 end

--- a/local_test/fail_spec.rb
+++ b/local_test/fail_spec.rb
@@ -9,6 +9,7 @@ describe 'test2' do
 
   it 'will be pending' do
     pending
+    expect(1).to eq(2)
   end
 
   it 'will be skipped' do

--- a/local_test/rrr.rb
+++ b/local_test/rrr.rb
@@ -3,14 +3,14 @@ require 'rrrspec/client/rspec_runner'
 require 'rrrspec/client/slave_runner'
 
 rspec_runner = RRRSpec::Client::RSpecRunner.new
-rspec_runner.reset
 ARGV.each do |path|
+  rspec_runner.reset
   status, outbuf, errbuf = rspec_runner.setup(path)
   p [status, outbuf, errbuf]
   unless status
     next
   end
-  formatter = RRRSpec::Client::SlaveRunner::RedisReportingFormatter.new
+  formatter = RRRSpec::Client::SlaveRunner::RedisReportingFormatter
   status, outbuf, errbuf = rspec_runner.run(formatter)
   p [status, outbuf, errbuf]
   if status

--- a/local_test/success_spec.rb
+++ b/local_test/success_spec.rb
@@ -1,5 +1,5 @@
 describe 'test1' do
   it 'will be succeeded' do
-    1.should == 1
+    expect(1).to eq(1)
   end
 end

--- a/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
+++ b/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
@@ -6,9 +6,7 @@ module RRRSpec
     class RSpecRunner
       def initialize
         @options = RSpec::Core::ConfigurationOptions.new([])
-        @options.parse_options
         @configuration = RSpec.configuration
-        @configuration.setup_load_path_and_require([])
         @world = RSpec.world
         @before_suite_run = false
       end
@@ -39,7 +37,7 @@ module RRRSpec
             @configuration.load_spec_files
             @world.announce_filters
             unless @before_suite_run
-              @configuration.run_hook(:before, :suite)
+              run_before_suite_hooks
               @before_suite_run = true
             end
             status = true
@@ -59,21 +57,11 @@ module RRRSpec
           @configuration.output_stream = $stdout
           @configuration.error_stream = $stderr
           @configuration.add_formatter(RSpec::Core::Formatters::BaseTextFormatter)
-          if @configuration.respond_to?(:formatter_loader)
-            # RSpec >= 2.99
-            formatters.each do |formatter|
-              @configuration.formatter_loader.formatters << formatter
-            end
-          else
-            formatters.each do |formatter|
-              @configuration.formatters << formatter
-            end
+          formatters.each do |formatter|
+            @configuration.formatter_loader.formatters << formatter
           end
-          @configuration.reporter.report(
-            @world.example_count,
-            @configuration.randomize? ? @configuration.seed : nil
-          ) do |reporter|
-            @world.example_groups.ordered.each do |example_group|
+          @configuration.reporter.report(@world.example_count) do |reporter|
+            @world.ordered_example_groups.each do |example_group|
               example_group.run(reporter)
             end
           end
@@ -86,6 +74,16 @@ module RRRSpec
       def reset
         @world.example_groups.clear
         @configuration.reset
+      end
+
+      private
+
+      def run_before_suite_hooks
+        hooks = @configuration.instance_variable_get(:@before_suite_hooks)
+        hook_context = RSpec::Core::SuiteHookContext.new
+        hooks.each do |h|
+          h.run(hook_context)
+        end
       end
     end
   end

--- a/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
+++ b/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
@@ -58,7 +58,7 @@ module RRRSpec
           @configuration.error_stream = $stderr
           @configuration.add_formatter(RSpec::Core::Formatters::BaseTextFormatter)
           formatters.each do |formatter|
-            @configuration.formatter_loader.formatters << formatter
+            @configuration.add_formatter(formatter)
           end
           @configuration.reporter.report(@world.example_count) do |reporter|
             @world.ordered_example_groups.each do |example_group|

--- a/rrrspec-client/rrrspec-client.gemspec
+++ b/rrrspec-client/rrrspec-client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "extreme_timeout"
   spec.add_dependency "launchy"
   spec.add_dependency "redis"
-  spec.add_dependency "rspec", ">= 2.14.1", "< 3"
+  spec.add_dependency "rspec", ">= 3.0"
   spec.add_dependency "thor"
   spec.add_dependency "uuidtools"
   spec.add_dependency "tzinfo"


### PR DESCRIPTION
Support RSpec 3.x and drop support for RSpec 2.x.
The key change is to follow changes of formatter specification.

@cookpad/rrrspec please review