### PR TITLE
Drop API v1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Create 'rrrspec-server-config.rb'
         pool: 5,
         host: 'localhost'
       }
-      conf.json_cache_path = '/vol/rrrspec-api-cache'
       conf.execute_log_text_path = '/vol/rrrspec-log-texts'
     end
 

--- a/rrrspec-server/lib/rrrspec/server/configuration.rb
+++ b/rrrspec-server/lib/rrrspec/server/configuration.rb
@@ -5,7 +5,6 @@ module RRRSpec
     class ServerConfiguration < Configuration
       attr_accessor :persistence_db
       attr_accessor :execute_log_text_path
-      attr_accessor :json_cache_path
       attr_accessor :daemonize, :pidfile, :user
       attr_accessor :stdout_path, :stderr_path
       attr_accessor :monitor

--- a/rrrspec-server/spec/rrrspec/server/persister_spec.rb
+++ b/rrrspec-server/spec/rrrspec/server/persister_spec.rb
@@ -120,27 +120,6 @@ module RRRSpec
           end
         end
       end
-
-      describe '.create_api_cache' do
-        before { Persister.persist(@taskset) }
-
-        it 'writes cached json file' do
-          Dir.mktmpdir do |dir|
-            Persister.create_api_cache(@taskset, dir)
-            json_path = File.join(dir, 'v1', 'tasksets', @taskset.key.gsub(':', '-'))
-            expect(File).to exist(json_path)
-            expect(File).to exist(json_path + ".gz")
-
-            p_taskset = Persistence::Taskset.first
-            expect(IO.read(json_path)).to eq(
-              JSON.generate(p_taskset.as_full_json.update('is_full' => true))
-            )
-            expect(Zlib::GzipReader.open(json_path + ".gz").read).to eq(
-              IO.read(json_path)
-            )
-          end
-        end
-      end
     end
   end
 end

--- a/rrrspec-web/lib/rrrspec/web/api.rb
+++ b/rrrspec-web/lib/rrrspec/web/api.rb
@@ -6,56 +6,6 @@ module RRRSpec
   module Web
     DEFAULT_PER_PAGE = 10
 
-    class API < Grape::API
-      version 'v1', using: :path
-      format :json
-      set :per_page, DEFAULT_PER_PAGE
-
-      resource :tasksets do
-        desc "Return active tasksets"
-        get :actives do
-          ActiveTaskset.list
-        end
-
-        desc "Return recently finished tasksets"
-        get :recents do
-          paginate(RRRSpec::Server::Persistence::Taskset.recent).map(&:as_json_with_no_relation)
-        end
-
-        desc "Return tasksets that contains failure_exit slave"
-        get :failure_slaves do
-          paginate(RRRSpec::Server::Persistence::Taskset.has_failed_slaves.recent).map(&:as_json_with_no_relation)
-        end
-
-        desc "Return a taskset."
-        params { requires :key, type: String, desc: "Taskset key." }
-        route_param :key do
-          get do
-            p_obj = RRRSpec::Server::Persistence::Taskset.where(key: params[:key]).full.first
-            if p_obj
-              p_obj.as_full_json.update('is_full' => true)
-            else
-              error!('Not Found', 404)
-            end
-          end
-        end
-      end
-
-      namespace :batch do
-        resource :tasks do
-          desc "Return all tasks in the taskset"
-          params { requires :key, type: String, desc: "Taskset key." }
-          route_param :key do
-            get do
-              r_taskset = Taskset.new(params[:key])
-              error!('Not Found', 404) unless r_taskset.exist?
-              r_taskset.tasks.map(&:to_h)
-            end
-          end
-        end
-      end
-    end
-
     module OjFormatter
       def self.call(object, env)
         Oj.dump(object, mode: :compat, time_format: :ruby)

--- a/rrrspec-web/spec/rrrspec/web/api_spec.rb
+++ b/rrrspec-web/spec/rrrspec/web/api_spec.rb
@@ -73,69 +73,6 @@ module RRRSpec
       worker_log.set_finished_time
     end
 
-    describe Web::API do
-      include Rack::Test::Methods
-
-      def app
-        Web::API
-      end
-
-      describe "GET /v1/tasksets/actives" do
-        before { ActiveTaskset.add(taskset) }
-
-        it 'returns the active tasksets' do
-          get "/v1/tasksets/actives"
-          expect(last_response.status).to eq(200)
-          expect(JSON.parse(last_response.body)).to eq(JSON.parse(ActiveTaskset.list.to_json))
-        end
-      end
-
-      describe "GET /v1/tasksets/recents" do
-        context 'there are 11 tasksets' do
-          before do
-            11.times { Server::Persistence::Taskset.create() }
-          end
-
-          it 'returns the recent 10 tasksets' do
-            get "/v1/tasksets/recents"
-            expect(last_response.status).to eq(200)
-            expect(JSON.parse(last_response.body).size).to eq(10)
-          end
-        end
-      end
-
-      describe "GET /v1/tasksets/:key" do
-        context 'with the taskset persisted' do
-          before do
-            Server::Persister.persist(taskset)
-          end
-
-          it 'returns the taskset' do
-            get "/v1/tasksets/#{taskset.key}"
-            expect(last_response.status).to eq(200)
-            expect(JSON.parse(last_response.body)).to eq(
-              JSON.parse(Server::Persistence::Taskset.first.as_full_json.to_json).update("is_full" => true)
-            )
-          end
-        end
-
-        context 'with the taskset not persisted' do
-          it 'returns 404' do
-            get "/v1/tasksets/#{taskset.key}"
-            expect(last_response.status).to eq(404)
-          end
-        end
-      end
-
-      describe "GET /v1/batch/tasks/:key" do
-        it 'returns all tasks in the taskset' do
-          get "/v1/batch/tasks/#{taskset.key}"
-          expect(last_response.status).to eq(200)
-          expect(JSON.parse(last_response.body)).to eq([JSON.parse(task.to_json)])
-        end
-      end
-    end
-
     describe Web::APIv2 do
       include Rack::Test::Methods
 


### PR DESCRIPTION
v1 API is no longer used and it only consumes disk usage by API cache.
@cookpad/rrrspec :question: 