### PR TITLE
Specify the minimum version of thor to avoid NoMethodError

### DIFF
--- a/rrrspec-client/rrrspec-client.gemspec
+++ b/rrrspec-client/rrrspec-client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "launchy"
   spec.add_dependency "redis"
   spec.add_dependency "rspec", ">= 3.0"
-  spec.add_dependency "thor"
+  spec.add_dependency "thor", ">= 0.18.0"
   spec.add_dependency "uuidtools"
   spec.add_dependency "tzinfo"
 end

--- a/rrrspec-server/rrrspec-server.gemspec
+++ b/rrrspec-server/rrrspec-server.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "facter"
   spec.add_dependency "redis"
   spec.add_dependency "rrrspec-client"
-  spec.add_dependency "thor"
+  spec.add_dependency "thor", ">= 0.18.0"
 end


### PR DESCRIPTION
I got the following error when executing `rrrspec-server server --config=rrrspec-server-config.rb`.

```
/path/to/.rbenv/versions/2.1.5/gemsets/pixta/gems/rrrspec-server-0.4.2/lib/rrrspec/server/cli.rb:7:in `<class:CLI>': undefined method `package_name' for RRRSpec::Server::CLI:Class (NoMethodError)
	from /path/to/.rbenv/versions/2.1.5/gemsets/pixta/gems/rrrspec-server-0.4.2/lib/rrrspec/server/cli.rb:6:in `<module:Server>'
	from /path/to/.rbenv/versions/2.1.5/gemsets/pixta/gems/rrrspec-server-0.4.2/lib/rrrspec/server/cli.rb:5:in `<module:RRRSpec>'
	from /path/to/.rbenv/versions/2.1.5/gemsets/pixta/gems/rrrspec-server-0.4.2/lib/rrrspec/server/cli.rb:4:in `<top (required)>'
	from /path/to/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
	from /path/to/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
	from /path/to/.rbenv/versions/2.1.5/gemsets/pixta/gems/rrrspec-server-0.4.2/bin/rrrspec-server:3:in `<top (required)>'
	from /path/to/.rbenv/versions/2.1.5/gemsets/pixta/bin/rrrspec-server:23:in `load'
	from /path/to/.rbenv/versions/2.1.5/gemsets/pixta/bin/rrrspec-server:23:in `<main>'
```

As far as I checked [thor](https://github.com/erikhuda/thor), it raised for the following reasons.

* `Thor.package_name` is added in v0.18.0 (ref. [CHANGELOG.md](https://github.com/erikhuda/thor/blob/master/CHANGELOG.md#0180-release-2013-03-26))
* But I used the lower version of thor.

This PR fixes the error by specifing the minimum version of thor.