### PR TITLE
Fix example in documentation so it helps to avoid misconfiguration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Create 'rrrspec-server-config.rb'
         pool: 5,
         host: 'localhost'
       }
-      conf.execute_log_text_path = '/vol/rrrspec-log-texts'
+      conf.execute_log_text_path = '/tmp/rrrspec-log-texts'
     end
 
     RRRSpec.configure(:worker) do |conf|


### PR DESCRIPTION
Small update for example configuration to avoid misconfiguration. Default value of ```execute_log_text_path``` is ```/tmp/rrrspec-log-texts```, so it's better to use this value, because ```execute_log_text_path``` is not documented well. People should not face same issues as me #49 at least when using default configuration based on provided example.