### PR TITLE
Fix output stream redirection

### DIFF
--- a/rrrspec-client/lib/rrrspec/client/base_text_formatter.rb
+++ b/rrrspec-client/lib/rrrspec/client/base_text_formatter.rb
@@ -1,0 +1,13 @@
+require 'rspec/core/formatters/base_text_formatter'
+
+module RRRSpec
+  module Client
+    class BaseTextFormatter < RSpec::Core::Formatters::BaseTextFormatter
+      RSpec::Core::Formatters.register(self, :message, :dump_summary, :dump_failures, :dump_pending, :seed)
+
+      def close(_notification)
+        # Do not close `output` .
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Reuse the same StringIO to pass RSpec's output stream check
- Setup formatter and output stream in setup phase
  - `setup` can initialize reporter
  - e.g., when config.filter_run_excluding is used