### PR TITLE
Fix bug STDOUT isn't captured

### DIFF
--- a/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
+++ b/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
@@ -39,7 +39,7 @@ module RRRSpec
             @options.configure(@configuration)
             @configuration.output_stream = $stdout
             @configuration.error_stream = $stderr
-            @configuration.default_formatter = BaseTextFormatter
+            @configuration.add_formatter(BaseTextFormatter)
             @configuration.files_to_run = [filepath]
             @configuration.load_spec_files
             @world.announce_filters


### PR DESCRIPTION
Problem
-----

In my environment, rrrspec doesn't capture stdout in second and subsequent.


example
-----

Focus on one slave.

First time
<img width="678" alt="screen shot 2016-09-01 at 19 29 23" src="https://cloud.githubusercontent.com/assets/4361134/18164377/7a5c7568-707a-11e6-8c61-12f92385e470.png">


Second time

<img width="655" alt="screen shot 2016-09-01 at 19 29 41" src="https://cloud.githubusercontent.com/assets/4361134/18164383/80606bae-707a-11e6-97f4-a5d9687ecbdc.png">

STDOUT is empty.

version
----

- RRRSpec 0.4.3

