### PR TITLE
Fix for rspec-core 3.5.3

### DIFF
--- a/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
+++ b/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
@@ -84,9 +84,19 @@ module RRRSpec
 
       def run_before_suite_hooks
         hooks = @configuration.instance_variable_get(:@before_suite_hooks)
-        hook_context = RSpec::Core::SuiteHookContext.new
         hooks.each do |h|
           h.run(hook_context)
+        end
+      end
+
+      def hook_context
+        @hook_context ||= begin
+          if RSpec::Core::Version::STRING < '3.5.3'
+            RSpec::Core::SuiteHookContext.new
+          else
+            RSpec::Core::SuiteHookContext
+              .new('before(:suite)', @configuration.reporter)
+          end
         end
       end
     end

--- a/rrrspec-client/spec/rrrspec/client/rspec_runner_spec.rb
+++ b/rrrspec-client/spec/rrrspec/client/rspec_runner_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'rrrspec/client/rspec_runner'
+
+module RRRSpec
+  module Client
+    RSpec.describe RSpecRunner do
+      describe '#setup' do
+        before do
+          RRRSpec.configuration = Configuration.new
+        end
+
+        let(:runner) { described_class.new }
+
+        it 'should be able to setup' do
+          status, _outbuf, _errbuf = runner.setup(__FILE__)
+          expect(status).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR should fix an error when running specs with spec-core 3.5.3.

In spec-core 3.5.3, method signature of `RSpec::Core::SuiteHookContext#initialize` is changed to receive 2 arguments. This change causes an error like following when you run specs.

```
                STDERR:
                Key:      rrrspec:taskset:1a3b7fbe-8185-11e6-a545-0242ac130006:t
ask:spec/success_spec.rb:trial:1f417de2-8185-11e6-88c0-0242ac130005
                Slave:    rrrspec:worker:45cb2488947f:slave:183
                Status:   error
                Started:
                Finished: 2016-09-23 12:00:03 UTC
                Passed:
                Pending:
                Failed:
                STDOUT:
                        wrong number of arguments (given 0, expected 2)
                        /usr/local/bundle/gems/rspec-core-3.5.3/lib/rspec/core/example.rb:635:in `initialize'
                        /usr/local/bundle/gems/rrrspec-client-0.4.3/lib/rrrspec/client/rspec_runner.rb:87:in `new'
                        /usr/local/bundle/gems/rrrspec-client-0.4.3/lib/rrrspec/client/rspec_runner.rb:87:in `run_before_suite_hooks'
                        /usr/local/bundle/gems/rrrspec-client-0.4.3/lib/rrrspec/client/rspec_runner.rb:47:in `block in setup'
```
