### PR TITLE
Make expandable areas noticeable

### DIFF
--- a/rrrspec-web/assets/stylesheets/application.sass
+++ b/rrrspec-web/assets/stylesheets/application.sass
@@ -1,3 +1,4 @@
+@import "bootstrap-sprockets"
 @import "bootstrap"
 
 body

--- a/rrrspec-web/views/taskset.haml
+++ b/rrrspec-web/views/taskset.haml
@@ -39,11 +39,15 @@
               %li.estimate-sec Avg.
 
       .worker-logs
-        .worker-logs-heading WORKERS
+        .worker-logs-heading
+          WORKERS
+          %span.glyphicon.glyphicon-menu-down.pull-right
         %ul.worker-logs-list
 
       .slaves
-        .slaves-heading SLAVES
+        .slaves-heading
+          SLAVES
+          %span.glyphicon.glyphicon-menu-down.pull-right
         %ul.slaves-list
 
       %script#head-template{type: 'text/template'}


### PR DESCRIPTION
Added arrow glyphicons to indicate that expandable areas are expandable (!).

## Screenshots
<img width="1197" alt="screenshot_2017-09-29_at_14_56_18" src="https://user-images.githubusercontent.com/1992308/31002877-f489457c-a527-11e7-8ee6-661305b21a23.png">
