### PR TITLE
Make master container wait for db to start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Kohei Suzuki <eagletmt@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-  apt-get install -y nodejs rsync ssh && \
+  apt-get install -y nodejs rsync ssh mysql-client && \
   update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10 && \
   apt-get clean
 RUN gem install --no-ri --no-rdoc foreman

--- a/local_test/run_master.sh
+++ b/local_test/run_master.sh
@@ -13,10 +13,11 @@ service ssh start
 trap 'at_exit' EXIT
 
 cd rrrspec-server
-until bundle exec rake rrrspec:server:db:create rrrspec:server:db:migrate RRRSPEC_CONFIG_FILES=/app/local_test/server_config.rb
+until MYSQL_PWD="$DB_PASSWORD" mysqladmin ping -h "$DB_HOST"
 do
-       sleep 3
+  sleep 3
 done
+bundle exec rake rrrspec:server:db:create rrrspec:server:db:migrate RRRSPEC_CONFIG_FILES=/app/local_test/server_config.rb
 
 foreman start -f /app/local_test/Procfile.master &
 wait

--- a/local_test/run_master.sh
+++ b/local_test/run_master.sh
@@ -13,7 +13,10 @@ service ssh start
 trap 'at_exit' EXIT
 
 cd rrrspec-server
-bundle exec rake rrrspec:server:db:create rrrspec:server:db:migrate RRRSPEC_CONFIG_FILES=/app/local_test/server_config.rb
+until bundle exec rake rrrspec:server:db:create rrrspec:server:db:migrate RRRSPEC_CONFIG_FILES=/app/local_test/server_config.rb
+do
+       sleep 3
+done
 
 foreman start -f /app/local_test/Procfile.master &
 wait


### PR DESCRIPTION
`docker-compose up` often failed due to startup order of containers.