### PR TITLE
Fix local test not works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY rrrspec-web/rrrspec-web.gemspec /app/rrrspec-web/rrrspec-web.gemspec
 COPY rrrspec-web/lib/rrrspec/web/version.rb /app/rrrspec-web/lib/rrrspec/web/version.rb
 COPY rrrspec-web/Gemfile /app/rrrspec-web/Gemfile
 
-RUN cd rrrspec-server && bundle install -j4
-RUN cd rrrspec-web && bundle install -j4
+RUN cd rrrspec-server && bundle install -j4 --gemfile Gemfile
+RUN cd rrrspec-web && bundle install -j4 --gemfile Gemfile
 
 COPY . /app

--- a/rrrspec-client/rrrspec-client.gemspec
+++ b/rrrspec-client/rrrspec-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_dependency "activesupport"
-  spec.add_dependency "extreme_timeout"
+  spec.add_dependency "extreme_timeout", ">=0.3.2"
   spec.add_dependency "launchy"
   spec.add_dependency "redis"
   spec.add_dependency "rspec", ">= 3.0"


### PR DESCRIPTION
Local test not works because of some errors.

### unicorn server not started at master container

```
$ docker-compose up
# ...
master_1  | + foreman start -f /app/local_test/Procfile.master
master_1  | 08:42:13 web.1    | started with pid 31
master_1  | 08:42:14 web.1    | bundler: command not found: unicorn
master_1  | 08:42:14 web.1    | Install missing gem executables with `bundle install`
master_1  | 08:42:14 master.1 | Loading: /app/local_test/server_config.rb
master_1  | 08:42:14 web.1    | exited with code 127
master_1  | 08:42:14 system   | sending SIGTERM to all processes
master_1  | 08:42:15 master.1 | terminated by SIGTERM
```

This error is caused by gem dependencies installation failure.
In Dockerfile, `bundle install` in `client` directory uses `server/Gemfile.lock` instead of `client/Gemfile`.
It seems to me that `Gemfile.lock` in another directory has higher priority than `Gemfile` in current directory.
So, I specify gemfile to use.

### SEGV at client container

```
$ docker-compose run worker local_test/run_client.sh
# ...
Slaves:
    Key:    rrrspec:worker:6d90b6d9cb35:slave:254
    Status: failure_exit
    Trials:
        rrrspec:taskset:6d67dbd0-f9d7-11e7-87a0-0242ac120006:task:local_test/fail_spec.rb:trial:6f51c1a4-f9d7-11e7-816e-0242ac120005
    Log:
        2018-01-15 09:35:31 ERR + cd local_test
        2018-01-15 09:35:31 ERR + bundle exec ../rrrspec-client/bin/rrrspec-client slave
        2018-01-15 09:35:33 ERR Loading: /app/local_test/worker_config.rb
        2018-01-15 09:35:34 ERR /app/rrrspec-client/lib/rrrspec/client/slave_runner.rb:74: [BUG] Segmentation fault at 0x0000000000000018
        2018-01-15 09:35:34 ERR ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-linux]
```

This error is caused by older [extreme_timeout](https://github.com/draftcode/extreme_timeout) gem.(fixed by https://github.com/draftcode/extreme_timeout/pull/6)