### PR TITLE
Fail when outside error occurred

### DIFF
--- a/local_test/client_config.rb
+++ b/local_test/client_config.rb
@@ -22,6 +22,7 @@ RRRSpec.configure(:client) do |conf|
       'local_test/success_spec.rb',
       'local_test/fail_spec.rb',
       'local_test/timeout_spec.rb',
+      'local_test/error_outside_examples_spec.rb',
     ]
   end
   conf.setup_command = <<-END

--- a/local_test/client_config.rb
+++ b/local_test/client_config.rb
@@ -22,7 +22,8 @@ RRRSpec.configure(:client) do |conf|
       'local_test/success_spec.rb',
       'local_test/fail_spec.rb',
       'local_test/timeout_spec.rb',
-      'local_test/error_outside_examples_spec.rb',
+      # this file is commented-out because it cause false positive of other tests.
+      # 'local_test/error_outside_examples_spec.rb',
     ]
   end
   conf.setup_command = <<-END

--- a/local_test/error_outside_examples_spec.rb
+++ b/local_test/error_outside_examples_spec.rb
@@ -1,0 +1,8 @@
+describe 'test4' do
+  describe 'outside error' do
+    include_context 'not exist context'
+    it 'cause outside error' do
+      expect(1).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
# Problem

rrrspec reports false results when `errors_outside_of_examples` has positive counts; for example, `include_context` is used but no context in it.
In this case, examples in other files are also skipped.

Local test result of https://github.com/cookpad/rrrspec/commit/2567d87e2a14c9dd941076a7b8b2e8e925004ebc  is here.

![2018-01-19 18 07 53](https://user-images.githubusercontent.com/1789266/35143090-bf65232e-fd43-11e7-9d1c-f2256c36be27.png)

# Solution

https://github.com/cookpad/rrrspec/commit/c38c379a516f2151a8891b9460cd18f19377dd80 fix that case by checking `errors_outside_of_examples_count` in report summary.
Local test result of the commit is here.

![2018-01-19 17 59 19](https://user-images.githubusercontent.com/1789266/35143094-c478c186-fd43-11e7-928a-f2d73ebf61b9.png)
