### PR TITLE
Replace `File|Dir.exists?` with `exist?`

### DIFF
--- a/rrrspec-client/lib/rrrspec/client/configuration.rb
+++ b/rrrspec-client/lib/rrrspec/client/configuration.rb
@@ -28,7 +28,7 @@ module RRRSpec
       def check_validity
         validity = super
 
-        unless Dir.exists?(packaging_dir)
+        unless Dir.exist?(packaging_dir)
           $stderr.puts("The packaging_dir does not exists: '#{packaging_dir}'")
           validity = false
         end
@@ -38,7 +38,7 @@ module RRRSpec
           validity = false
         else
           spec_files.each do |filepath|
-            unless File.exists?(File.join(packaging_dir, filepath))
+            unless File.exist?(File.join(packaging_dir, filepath))
               $stderr.puts("One of the spec_files does not exists '#{filepath}'")
               validity = false
             end

--- a/rrrspec-client/lib/rrrspec/configuration.rb
+++ b/rrrspec-client/lib/rrrspec/configuration.rb
@@ -30,7 +30,7 @@ module RRRSpec
       loaded = []
       files.each do |filepath|
         filepath = File.absolute_path(filepath)
-        next unless File.exists?(filepath)
+        next unless File.exist?(filepath)
         $stderr.puts("Loading: #{filepath}")
         load filepath
         loaded << filepath

--- a/rrrspec-server/lib/rrrspec/server/worker_runner.rb
+++ b/rrrspec-server/lib/rrrspec/server/worker_runner.rb
@@ -23,7 +23,7 @@ module RRRSpec
         logger.write("Start RSync")
 
         working_path = File.join(RRRSpec.configuration.working_dir, taskset.rsync_name)
-        FileUtils.mkdir_p(working_path) unless Dir.exists?(working_path)
+        FileUtils.mkdir_p(working_path) unless Dir.exist?(working_path)
         remote_path = File.join(RRRSpec.configuration.rsync_remote_path, taskset.rsync_name)
         command = "rsync #{RRRSpec.configuration.rsync_options} #{remote_path}/ #{working_path}"
 


### PR DESCRIPTION
`File.exists?` and `Dir.exists?` are deprecated. Use `.exist?` instead.

```bash
$ ruby -we 'File.exists?("a"); Dir.exists?("a")'
-e:1: warning: File.exists? is a deprecated name, use File.exist? instead
-e:1: warning: Dir.exists? is a deprecated name, use Dir.exist? instead
```