### PR TITLE
update grape for CVE-2018-3769

### DIFF
--- a/rrrspec-client/spec/spec_helper.rb
+++ b/rrrspec-client/spec/spec_helper.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
     retry_count = 1
     loop do
       begin
-        redis.client.connect
+        redis.ping
         break
       rescue Redis::CannotConnectError
         if retry_count < 10

--- a/rrrspec-server/spec/spec_helper.rb
+++ b/rrrspec-server/spec/spec_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
     retry_count = 1
     loop do
       begin
-        redis.client.connect
+        redis.ping
         break
       rescue Redis::CannotConnectError
         if retry_count < 10

--- a/rrrspec-web/lib/rrrspec/web/api.rb
+++ b/rrrspec-web/lib/rrrspec/web/api.rb
@@ -16,7 +16,6 @@ module RRRSpec
       version 'v2', using: :path
       format :json
       formatter :json, OjFormatter
-      set :per_page, DEFAULT_PER_PAGE
 
       rescue_from(ActiveRecord::RecordNotFound) do
         [404, {}, ['']]
@@ -24,6 +23,7 @@ module RRRSpec
 
       # For Index
 
+      paginate per_page: DEFAULT_PER_PAGE
       get '/tasksets/actives' do
         ActiveTaskset.list.map do |taskset|
           {
@@ -35,6 +35,7 @@ module RRRSpec
         end
       end
 
+      paginate per_page: DEFAULT_PER_PAGE
       get '/tasksets/recents' do
         paginate(RRRSpec::Server::Persistence::Taskset.recent).map(&:as_json_for_index)
       end

--- a/rrrspec-web/rrrspec-web.gemspec
+++ b/rrrspec-web/rrrspec-web.gemspec
@@ -31,10 +31,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3"
   spec.add_dependency "activerecord", "~> 4.2.0"
   spec.add_dependency "activesupport"
-  spec.add_dependency "api-pagination", "< 3.2.0"
+  spec.add_dependency "api-pagination", "~> 4.8.1"
   spec.add_dependency "bootstrap-sass", ">= 3.2"
   spec.add_dependency "coffee-script", "~> 2.2.0"
-  spec.add_dependency "grape", '~> 0.9.0'
+  spec.add_dependency "grape", '~> 1.1.0'
   spec.add_dependency "haml", "~> 4.0.3"
   spec.add_dependency "kaminari", "~> 0.16.0"
   spec.add_dependency "oj"

--- a/rrrspec-web/spec/spec_helper.rb
+++ b/rrrspec-web/spec/spec_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
     retry_count = 1
     loop do
       begin
-        redis.client.connect
+        redis.ping
         break
       rescue Redis::CannotConnectError
         if retry_count < 10


### PR DESCRIPTION
This PR updates grape gem that rrrspec-web depends on for [CVE-2018-3769](https://nvd.nist.gov/vuln/detail/CVE-2018-3769).

It also updates api-pagination gem because of newer version of grape.

In `Gemfile` of rrrspec-web, it fixes version of redis gem because of https://github.com/antirez/redis/issues/4272