### PR TITLE
Set error status when some error occurred outside of examples

### DIFF
--- a/local_test/client_config.rb
+++ b/local_test/client_config.rb
@@ -22,6 +22,7 @@ RRRSpec.configure(:client) do |conf|
       'local_test/success_spec.rb',
       'local_test/fail_spec.rb',
       'local_test/timeout_spec.rb',
+      'local_test/error_spec.rb',
     ]
   end
   conf.setup_command = <<-END

--- a/local_test/error_spec.rb
+++ b/local_test/error_spec.rb
@@ -1,0 +1,4 @@
+describe UndefinedConstant do
+  it 'never be executed' do
+  end
+end

--- a/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
+++ b/rrrspec-client/lib/rrrspec/client/rspec_runner.rb
@@ -77,6 +77,7 @@ module RRRSpec
 
       def reset
         @world.example_groups.clear
+        @world.wants_to_quit = false
         @configuration.reset
       end
 

--- a/rrrspec-client/lib/rrrspec/client/slave_runner.rb
+++ b/rrrspec-client/lib/rrrspec/client/slave_runner.rb
@@ -92,7 +92,7 @@ module RRRSpec
       end
 
       class RedisReportingFormatter
-        RSpec::Core::Formatters.register(self, :example_passed, :example_pending, :example_failed)
+        RSpec::Core::Formatters.register(self, :example_passed, :example_pending, :example_failed, :dump_summary)
 
         def initialize(_output)
           self.class.reset
@@ -110,13 +110,18 @@ module RRRSpec
           self.class.example_failed(notification)
         end
 
+        def dump_summary(notification)
+          self.class.dump_summary(notification)
+        end
+
         module ClassMethods
-          attr_reader :passed, :pending, :failed
+          attr_reader :passed, :pending, :failed, :errors_outside_of_examples_count
 
           def reset
             @passed = 0
             @pending = 0
             @failed = 0
+            @errors_outside_of_examples_count = 0
             @timeout = false
           end
 
@@ -135,9 +140,15 @@ module RRRSpec
             end
           end
 
+          def dump_summary(notification)
+            @errors_outside_of_examples_count = notification.errors_outside_of_examples_count
+          end
+
           def status
             if @timeout
               'timeout'
+            elsif @errors_outside_of_examples_count != 0
+              'error'
             elsif @failed != 0
               'failed'
             elsif @pending != 0


### PR DESCRIPTION
Errors outside examples (e.g., exceptions while loading spec files) are handled by RSpec core since v3.6.
http://rspec.info/blog/2017/05/rspec-3-6-has-been-released/
By this change, RSpecRunner has to handle such errors and reset wants_to_quit flag.

@cookpad/dev-infra please review